### PR TITLE
mesh_vpn needs to be enabled as default

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -38,6 +38,7 @@
   },
 
   mesh_vpn = {
+    enabled = true,
     mtu = 1280,
     bandwidth_limit = {
       enabled = false,


### PR DESCRIPTION
Is per default disabled by default on a fresh installed router